### PR TITLE
React fiber compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "iojs"
+  - "6"
 script:
   - npm test

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "babel": "^5.5.8",
     "babel-core": "^5.6.18",
-    "babel-eslint": "^3.1.15",
+    "babel-eslint": "^4.1.8",
     "eslint": "^0.23",
     "eslint-config-airbnb": "0.0.6",
     "eslint-plugin-react": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
     "eslint-config-airbnb": "0.0.6",
     "eslint-plugin-react": "^2.3.0",
     "expect": "^1.6.0",
+    "jsdom": "^7.2.2",
     "mocha": "^2.2.5",
-    "mocha-jsdom": "^1.0.0",
+    "mocha-jsdom": "^1.1.0",
     "react": "^0.14.0-rc1",
     "react-addons-test-utils": "^0.14.0-rc1",
     "rimraf": "^2.3.4"


### PR DESCRIPTION
This PR adds compatibility to the new React Fiber data structure. This fixes hot module reloading in React Native for React v16.

I've done the change in the `1.x` branch, since this is the one used by the `react-proxy` module, which is used for HMR, but a very similar PR can be done for v2.

The tests haven't been changed, to ensure the backwards compatibility, but I have a commit which updates React to v16 to prove that this works on React Fiber (https://github.com/rafeca/react-deep-force-update/commit/2eb66a933781fa6025fc7c19523c3a565dff1db2).

Ideally we should have tests for different versions of React, but this is out of scope of this PR :)