### PR TITLE
Fix outdated document in calling deepForceUpdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ const instance = render(<Something />);
 // Will force-update the whole rendered tree
 // even if components in the middle of it
 // define a strict shouldComponentUpdate().
-deepForceUpdate(instance);
+deepForceUpdate(React)(instance);
 ```
 
 ## React Native


### PR DESCRIPTION
It seems that the README is outdated, it should be `deepForceUpdate(React)(instance)` instead.